### PR TITLE
Scenario one test case

### DIFF
--- a/src/com/mywedding/pages/HomePage.java
+++ b/src/com/mywedding/pages/HomePage.java
@@ -22,6 +22,9 @@ public class HomePage extends Page {
 	@FindBy(id="tab-find-vendor")
 	private WebElement vendorTab;
 	
+	@FindBy(id="ideas-search")
+	private WebElement ideasSearch;
+	
 	/**
 	 * Constructor for HomePage. Has a dependency for a WebDriver instance, and will 
 	 * setup WebElements using Selenium's PageFactory.
@@ -46,5 +49,14 @@ public class HomePage extends Page {
 	public FindVendorPage navigateToFindVendorPage() {
 		vendorTab.click();
 		return new FindVendorPage(this.driver);
+	}
+	
+	/**
+	 * Check if the ideas search section is present on the page
+	 * 
+	 * @return whether or not ideas search is present
+	 */
+	public boolean isIdeasSearchElementPresent() {
+		return ideasSearch.isDisplayed();
 	}
 }

--- a/test/com/mywedding/pages/FindVendorPageTest.java
+++ b/test/com/mywedding/pages/FindVendorPageTest.java
@@ -2,6 +2,8 @@ package com.mywedding.pages;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
 
 import com.mywedding.basetest.BaseTestCase;
 
@@ -18,5 +20,24 @@ public class FindVendorPageTest extends BaseTestCase {
 		Assert.assertEquals(FindVendorPage.FINDVENDORPAGE_URL, vendorPage.getURL());
 	}
 	
-
+	/**
+	 * The ideas search section is <a href="http://prntscr.com/83e3tq"> this</a>, and we 
+	 * only want that to be present on the "Collect Ideas" tab, not the "Find Vendors" tab.
+	 */
+	@Test
+	public void ideasSearchSectionIsNotPresentOnTheFindVendorsPage() {
+		/* Given:
+		 * 		I am on the find vendor home page
+		 */
+		HomePage homePage = new HomePage(driver).navigateToHomePage();
+		FindVendorPage vendorPage = homePage.navigateToFindVendorPage();
+		Assert.assertEquals(FindVendorPage.FINDVENDORPAGE_URL, vendorPage.getURL());
+		
+		/* Then:
+		 * 		the ideas search section is not present on the find vendor home page
+		 */
+		WebElement ideasSearch = driver.findElement(By.id("ideas-search"));
+		Assert.assertFalse("ideas-search section should not be present on the Find Vendors Page", 
+				ideasSearch.isDisplayed());			
+	}
 }

--- a/test/com/mywedding/pages/HomePageTest.java
+++ b/test/com/mywedding/pages/HomePageTest.java
@@ -1,0 +1,16 @@
+package com.mywedding.pages;
+
+import org.junit.Test;
+import org.testng.Assert;
+
+import com.mywedding.basetest.BaseTestCase;
+
+public class HomePageTest extends BaseTestCase {
+	
+	@Test
+	public void ideasSearchSectionIsPresentOnHomePage() {
+		HomePage homePage = new HomePage(driver).navigateToHomePage();
+		Assert.assertTrue(homePage.isIdeasSearchElementPresent(), "Expected ideas search "
+				+ "section to be present on home page");
+	}
+}


### PR DESCRIPTION
Adding test case for scenario where we assert that the ideas-search element is not present on the find vendors page. It should, however be present on the "Collect Ideas" page, which is also our HomePage.